### PR TITLE
Fix ReadTrueColorMemoryBitmap: unsupported format exception

### DIFF
--- a/PdfSharp/Pdf.Advanced/PdfImage.cs
+++ b/PdfSharp/Pdf.Advanced/PdfImage.cs
@@ -835,10 +835,7 @@ namespace PdfSharp.Pdf.Advanced
 #endif
             int pdfVersion = Owner.Version;
             MemoryStream memory = new MemoryStream();
-#if CORE_WITH_GDI
-            _image._gdiImage.Save(memory, ImageFormat.Bmp);
-#endif
-#if GDI
+#if CORE_WITH_GDI || GDI
             _image._gdiImage.Save(memory, ImageFormat.Bmp);
 #endif
 #if WPF
@@ -1033,10 +1030,7 @@ namespace PdfSharp.Pdf.Advanced
             bool segmentedColorMask = false;
 
             MemoryStream memory = new MemoryStream();
-#if CORE_WITH_GDI
-            _image._gdiImage.Save(memory, ImageFormat.Bmp);
-#endif
-#if GDI
+#if CORE_WITH_GDI || GDI
             _image._gdiImage.Save(memory, ImageFormat.Bmp);
 #endif
 #if WPF


### PR DESCRIPTION
On linux (only) I got "ReadTrueColorMemoryBitmap: unsupported format" exception in this place.
When it builds with "GDI;CORE_WITH_GDI" compilation symbols, _image copies 2 times into memory stream.  It causes incorrect stream length and exception.
